### PR TITLE
avoid 404 error when clicking on country database

### DIFF
--- a/profiles/static/profiles/js/home-graphs.js
+++ b/profiles/static/profiles/js/home-graphs.js
@@ -96,7 +96,7 @@ $(document).ready(function() {
             const selection = chart.getSelection();
             if (selection.length > 0) {
                 const country = data.getValue(selection[0].row, 0);
-                window.location.href = '/list?s=' + encodeURIComponent(country);
+                window.location.href = '/repo/?s=' + encodeURIComponent(country);
             }
         });
 

--- a/profiles/templates/profiles/home.html
+++ b/profiles/templates/profiles/home.html
@@ -194,7 +194,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-secondary" id="PhDtext">PhD</span>
-			<p class="position-text"><a href="list?s=PhD%20student" id="student-count"> profiles</a></p>
+			<p class="position-text"><a href="repo?s=PhD%20student" id="student-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>
@@ -206,7 +206,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-tertiary" id="PostDoctext">Post-doc</span>
-			<p class="position-text"><a href="list?s=post-doc" id="postdoc-count"> profiles</a></p>
+			<p class="position-text"><a href="repo?s=post-doc" id="postdoc-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>
@@ -218,7 +218,7 @@
 				</tr>
 			</table>
 			<span class="position-title text-quaternary" id="Seniortext">Senior</span>
-			<p class="position-text"><a href="list?senior=on" id="senior-count"> profiles</a></p>
+			<p class="position-text"><a href="repo?senior=on" id="senior-count"> profiles</a></p>
 		</div>
 		<div class="p-2 text-center donutTab">
 			<table>


### PR DESCRIPTION
When someone would click on countries in the interactive world map on the homepage, a 404 error would occur - I added an explicit path for the profiles list & used re.escape instead of compile to escape special characters in search terms for regex matching. I tested the changes on a local deployment using 100, 500 and 1000 profiles and it worked just fine, but let me know if I can test anything else out to be sure. Thanks!

<img width="854" alt="error_database" src="https://github.com/WomenInNeuroscience/winrepo/assets/46607449/22bc705f-87bd-4037-a4d3-5a530900791a">
